### PR TITLE
Fix TypeError in file_selector.py

### DIFF
--- a/gpt_engineer/file_selector.py
+++ b/gpt_engineer/file_selector.py
@@ -292,7 +292,7 @@ def ask_for_files(metadata_db: DB, workspace_db: DB) -> None:
         sys.exit(1)
 
     if not selection_number == 3:
-        metadata_db[FILE_LIST_NAME] = "\n".join(file_path_list)
+        metadata_db[FILE_LIST_NAME] = "\n".join(str(file_path) for file_path in file_path_list)
 
 
 def gui_file_selector(input_path: str) -> List[str]:


### PR DESCRIPTION
Updated file_selector.py to handle WindowsPath objects by converting them to strings before joining. This resolves the TypeError encountered when trying to join WindowsPath objects directly.